### PR TITLE
Remove duplicate argument from mexZED.cpp + MATLAB examples InitialParameters

### DIFF
--- a/matlab/ZED_Camera.m
+++ b/matlab/ZED_Camera.m
@@ -12,7 +12,7 @@ mexZED('create');
 
 InitParameters.camera_resolution = 2; %HD720
 InitParameters.camera_fps = 60;
-InitParameters.system_units = 2; %METER
+InitParameters.coordinate_units = 2; %METER
 InitParameters.depth_mode = 1; %PERFORMANCE
 %InitParameters.svo_input_filename = '../mySVOfile.svo'; % Enable SVO playback
 result = mexZED('open', InitParameters)

--- a/matlab/ZED_PointCloud.m
+++ b/matlab/ZED_PointCloud.m
@@ -12,7 +12,7 @@ mexZED('create');
 
 InitParameters.camera_resolution = 2; %HD720
 InitParameters.camera_fps = 60;
-InitParameters.system_units = 2; %METER
+InitParameters.coordinate_units = 2; %METER
 InitParameters.depth_mode =  1; %PERFORMANCE
 InitParameters.coordinate_system = 3; %COORDINATE_SYSTEM_RIGHT_HANDED_Z_UP
 %InitParameters.svo_input_filename = '../mySVOfile.svo'; % Enable SVO playback

--- a/matlab/ZED_Tracking.m
+++ b/matlab/ZED_Tracking.m
@@ -12,7 +12,7 @@ mexZED('create');
 
 InitParameters.camera_resolution = 2; %HD720
 InitParameters.camera_fps = 60;
-InitParameters.system_units = 2; %METER
+InitParameters.coordinate_units = 2; %METER
 InitParameters.depth_mode = 1; %PERFORMANCE
 InitParameters.coordinate_system = 3; %COORDINATE_SYSTEM_RIGHT_HANDED_Z_UP
 %InitParameters.svo_input_filename = '../mySVOfile.svo'; % Enable SVO playback

--- a/src/mex/mexZED.cpp
+++ b/src/mex/mexZED.cpp
@@ -241,7 +241,6 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[]) {
                         if(!strcmp(field_name, "camera_resolution")) initParams.camera_resolution = static_cast<sl::RESOLUTION> (val);
                         if(!strcmp(field_name, "camera_fps")) initParams.camera_fps = val;
                         if(!strcmp(field_name, "svo_real_time_mode")) initParams.svo_real_time_mode = val;
-                        if(!strcmp(field_name, "camera_image_flip")) initParams.camera_image_flip = val;
                         if(!strcmp(field_name, "depth_stabilization")) initParams.depth_stabilization = val;
                         if(!strcmp(field_name, "enable_right_side_measure")) initParams.enable_right_side_measure = val;
                     }


### PR DESCRIPTION
1) mexZED.cpp

camera_image_flip argument is repeated in mexZED.cpp, once in line 239 and another in line 244

2) /matlab    examples.

InitialParameters.system_units do not exist.
Perhaps it was meant to be InitialParameters.coordinate_units.