### PR TITLE
Added compile problem with invalid inequality

### DIFF
--- a/src/mex/mexZED.cpp
+++ b/src/mex/mexZED.cpp
@@ -304,7 +304,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[]) {
             if(checkParams(nrhs, 1, 3)) {
                 double *ptr_ = mxGetPr(prhs[1]);
                 int val = ptr_[0];
-                if(val < sl::VIEW::LAST)
+                if(val < static_cast<int>(sl::VIEW::LAST))
                     view = static_cast<sl::VIEW>(val);
                 else {
 					mexWarnMsgTxt("Unknown VIEW requested");
@@ -342,7 +342,7 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[]) {
             if(checkParams(nrhs, 1, 3)) {
                 double *ptr_ = mxGetPr(prhs[1]);
                 int val = ptr_[0];
-                if(val < sl::VIEW::LAST)
+                if(val < static_cast<int>(sl::MEASURE::LAST))
                     measure = static_cast<sl::MEASURE>(val);
                 else {
                     mexWarnMsgTxt("Unknown MEASURE requested");


### PR DESCRIPTION
/zed-matlab/src/mex/mexZED.cpp: In function ‘void mexFunction(int, mxArray**, int, const mxArray**)’:
/zed-matlab/src/mex/mexZED.cpp:307:24: error: no match for ‘operator<’ (operand types are ‘int’ and ‘sl::VIEW’)
                 if(val < sl::VIEW::LAST)
                    ~~~~^~~~
/zed-matlab/src/mex/mexZED.cpp:345:24: error: no match for ‘operator<’ (operand types are ‘int’ and ‘sl::VIEW’)
                 if(val < sl::VIEW::LAST)
                    ~~~~^~~~
mex/CMakeFiles/mexZED.dir/build.make:62: recipe for target 'mex/CMakeFiles/mexZED.dir/mexZED.cpp.o' failed
make[2]: *** [mex/CMakeFiles/mexZED.dir/mexZED.cpp.o] Error 1
CMakeFiles/Makefile2:90: recipe for target 'mex/CMakeFiles/mexZED.dir/all' failed
make[1]: *** [mex/CMakeFiles/mexZED.dir/all] Error 2
Makefile:129: recipe for target 'all' failed
make: *** [all] Error 2